### PR TITLE
Patch:private network only

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,23 +1,29 @@
-# fly.toml file generated for redis-example on 2020-10-30T20:01:11-05:00
+# fly.toml file generated for cache on 2021-05-07T21:26:24+02:00
 
-app = "redis-example"
+app = "cache"
+
+kill_signal = "SIGINT"
+kill_timeout = 5
 
 [[mounts]]
 source      = "redis_server"
 destination = "/data"
 
+[env]
+  PRIMARY_REGION = "lhr"
+
+[experimental]
+  auto_rollback = true
+  private_network= true
+
 [[services]]
-internal_port = 6379
-protocol      = "tcp"
+  internal_port = 6379
+  protocol      = "tcp"
 
   [services.concurrency]
-  hard_limit = 25
-  soft_limit = 20
-
-  [[services.ports]]
-  handlers = []
-  port     = "10000"
+    hard_limit = 25
+    soft_limit = 20
 
   [[services.tcp_checks]]
-  interval = 10000
-  timeout  = 2000
+    interval = 10000
+    timeout  = 2000

--- a/start-redis-server.sh
+++ b/start-redis-server.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 sysctl vm.overcommit_memory=1
 sysctl net.core.somaxconn=1024
-redis-server --requirepass $REDIS_PASSWORD --bind 0.0.0.0 --dir /data/ --appendonly yes
+redis-server --requirepass $REDIS_PASSWORD --dir /data/ --appendonly yes


### PR DESCRIPTION
* Remove `--bind` option to implicitly bind to both `0.0.0.0` and `::`
* Rmove public network access from fly.toml.
